### PR TITLE
Add `start_address` argument to `adm` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ These commands must be run when the running status is `STOPPED`.
 * `get <address (in hex)>` - Gets instruction at address. Returns output word and number of clock cycles separated by a space, in same format as `set`.
 * `run` - Used to hardware start a programmed sequence (ie waits for external trigger before processing first instruction).
 * `swr` - Used to software start a programmed sequence (ie do not wait for a hardware trigger at sequence start).
-* `adm <number of instructions (in hex)>` - Enters mode for adding pulse instructions in binary.
-  * The number of instructions must be specified with the command. The Pi Pico will then wait for that enough bytes to fill that many instructions (6 times the number of instructions) to be read, and will not respond during this time unless there is an error. This mode can not be be terminated until that many bytes are read.
+* `adm <starting instruction address (in hex)> <number of instructions (in hex)>` - Enters mode for adding pulse instructions in binary.
+  * This command over-writes any existing instructions in memory. The starting instruction address specifies where to insert the block of instructions. This is generally set to 0 to write a complete instruction set from scratch.
+  * The number of instructions must be specified with the command. The Pi Pico will then wait for enough bytes (6 times the number of instructions) to be read, and will not respond during this time unless there is an error. This mode can not be be terminated until that many bytes are read.
   * Each instruction is specified by a 16 bit unsigned integer (little Endian, output 15 is most significant) specifying the state of the outputs and a 32 bit unsigned integer (little Endian) specifying the number of clock cycles.
     * The number of clock cycles sets how long this state is held before the next instruction.
     * If the number of clock cycles is 0, this indicates an indefinite wait.

--- a/prawn_do/prawn_do.c
+++ b/prawn_do/prawn_do.c
@@ -519,17 +519,21 @@ int main(){
 		// Add many command: read in a fixed number of binary integers without separation,
 		// append to command array
 		else if(strncmp(serial_buf, "adm", 3) == 0){
-			// Get how many instructions this adm command contains
+			// Get how many instructions this adm command contains and where to insert them
+			uint32_t start_addr;
 			uint32_t inst_count;
-			int parsed = sscanf(serial_buf, "%*s %x", &inst_count);
-			if(parsed < 1){
+			int parsed = sscanf(serial_buf, "%*s %x %x", &start_addr, &inst_count);
+			if(parsed < 2){
 				fast_serial_printf("Invalid request\r\n");
 			}
 
 			// Check that the instructions will fit in the do_cmds array
-			if(inst_count + do_cmd_count >= MAX_DO_CMDS - 3){
-				fast_serial_printf("Too many DO commands (%d + %d). Please use resources more efficiently or increase MAX_DO_CMDS and recompile.\r\n", do_cmd_count, inst_count);
+			if(inst_count + start_addr >= MAX_DO_CMDS - 3){
+				fast_serial_printf("Invalid address and/or too many instructions (%d + %d).\r\n", start_addr, inst_count);
 			}
+
+			// reset do_cmd_count to start_address
+			do_cmd_count = start_addr * 2;
 
 			// It takes 6 bytes to describe an instruction: 2 bytes for values, 4 bytes for time
 			uint32_t inst_per_buffer = SERIAL_BUFFER_SIZE / 6;

--- a/prawn_do/prawn_do.c
+++ b/prawn_do/prawn_do.c
@@ -528,7 +528,7 @@ int main(){
 			}
 
 			// Check that the instructions will fit in the do_cmds array
-			if(inst_count + start_addr >= MAX_DO_CMDS - 3){
+			if(inst_count + start_addr > MAX_INSTR){
 				fast_serial_printf("Invalid address and/or too many instructions (%d + %d).\r\n", start_addr, inst_count);
 			}
 


### PR DESCRIPTION
This removes the need to remember to call `cls` before every binary write. It also allows for some control of the binary write process.

Also fixed a bug where you could try to write too many instructions without a warning being put out.