### PR TITLE
Adm error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ These commands must be run when the running status is `STOPPED`.
 * `swr` - Used to software start a programmed sequence (ie do not wait for a hardware trigger at sequence start).
 * `adm <starting instruction address (in hex)> <number of instructions (in hex)>` - Enters mode for adding pulse instructions in binary.
   * This command over-writes any existing instructions in memory. The starting instruction address specifies where to insert the block of instructions. This is generally set to 0 to write a complete instruction set from scratch.
-  * The number of instructions must be specified with the command. The Pi Pico will then wait for enough bytes (6 times the number of instructions) to be read, and will not respond during this time unless there is an error. This mode can not be be terminated until that many bytes are read.
+  * The number of instructions must be specified with the command, which is used to determine the total number of bytes to be read (6 6 times the number of instructions).
+  * This command returns `Ready\r\n` to signify it is ready for binary data. The Pico will then read the total number of bytes. This mode can not be terminated until that many bytes are read.
   * Each instruction is specified by a 16 bit unsigned integer (little Endian, output 15 is most significant) specifying the state of the outputs and a 32 bit unsigned integer (little Endian) specifying the number of clock cycles.
     * The number of clock cycles sets how long this state is held before the next instruction.
     * If the number of clock cycles is 0, this indicates an indefinite wait.
@@ -86,25 +87,23 @@ The basis of the functionality for this serial interface was developed by Carter
 ## Clock Sync
 Firmware supports the use of an external clock. This prevents any significant phase slip between a pseudoclock and this digital output controller if their clocks are phase synchronous. Without external buffering hardware, clock must be LVCMOS compatible.
 
-## Example:
-Below program sets one output high for 1 microsecond, then low while setting the next output high for 1 microsecond (64 in hex = 100 in decimal) for 6 outputs, then stopping:
+## Examples:
+Below python script sets one output high for 1 microsecond, then low while setting the next output high for 1 microsecond (64 in hex = 100 in decimal) for 6 outputs, then stopping. `do` is a pyserial handle to the pico.
 
-Commands (`\n` explicitly denotes newline/pressing enter):
+```python
+bits = [1, 2, 3, 8, 10, 20, 0, 0]
+cycles = [100, 100, 100, 100, 100, 100, 0, 0]
 
-```
-add\n
-1 64\n
-2 64\n
-4 64\n
-8 64\n
-10 64\n
-20 64\n
-0 0\n
-0 0\n
-end\n
+do.write('add\n'.encode())
+for bit, cycle in zip(bits, cycles):
+  do.write(f'{bit:x} {cycle:x}\n'.encode())
+
+do.write('end\n'.encode())
+resp = do.readline().decode()
+assert resp == 'ok\r\n'
 ```
 
-
+Output of the above sequence.
 <img width="470" alt="documentation" src="https://github.com/pmiller2022/prawn_digital_output/assets/75953337/932b784f-346f-4598-8679-b857578e0291">
 
 This is a python script that employs the binary write `adm` command.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ These commands must be run when the running status is `STOPPED`.
 * `adm <starting instruction address (in hex)> <number of instructions (in hex)>` - Enters mode for adding pulse instructions in binary.
   * This command over-writes any existing instructions in memory. The starting instruction address specifies where to insert the block of instructions. This is generally set to 0 to write a complete instruction set from scratch.
   * The number of instructions must be specified with the command, which is used to determine the total number of bytes to be read (6 6 times the number of instructions).
-  * This command returns `Ready\r\n` to signify it is ready for binary data. The Pico will then read the total number of bytes. This mode can not be terminated until that many bytes are read.
+  * This command returns `ready\r\n` to signify it is ready for binary data. The Pico will then read the total number of bytes. This mode can not be terminated until that many bytes are read.
   * Each instruction is specified by a 16 bit unsigned integer (little Endian, output 15 is most significant) specifying the state of the outputs and a 32 bit unsigned integer (little Endian) specifying the number of clock cycles.
     * The number of clock cycles sets how long this state is held before the next instruction.
     * If the number of clock cycles is 0, this indicates an indefinite wait.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ These commands must be run when the running status is `STOPPED`.
 * `get <address (in hex)>` - Gets instruction at address. Returns output word and number of clock cycles separated by a space, in same format as `set`.
 * `run` - Used to hardware start a programmed sequence (ie waits for external trigger before processing first instruction).
 * `swr` - Used to software start a programmed sequence (ie do not wait for a hardware trigger at sequence start).
-* `adm <number of instructions (in hex)>` - Enters mode for adding pulse instructions in binary.
-  * The number of instructions must be specified with the command. The Pi Pico will then wait for that enough bytes to fill that many instructions (6 times the number of instructions) to be read, and will not respond during this time unless there is an error. This mode can not be be terminated until that many bytes are read.
+* `adm <starting instruction address (in hex)> <number of instructions (in hex)>` - Enters mode for adding pulse instructions in binary.
+  * This command over-writes any existing instructions in memory. The starting instruction address specifies where to insert the block of instructions. This is generally set to 0 to write a complete instruction set from scratch.
+  * The number of instructions must be specified with the command. The Pi Pico will then wait for enough bytes (6 times the number of instructions) to be read, and will not respond during this time unless there is an error. This mode can not be be terminated until that many bytes are read.
   * Each instruction is specified by a 16 bit unsigned integer (little Endian, output 15 is most significant) specifying the state of the outputs and a 32 bit unsigned integer (little Endian) specifying the number of clock cycles.
     * The number of clock cycles sets how long this state is held before the next instruction.
     * If the number of clock cycles is 0, this indicates an indefinite wait.

--- a/prawn_do/prawn_do.c
+++ b/prawn_do/prawn_do.c
@@ -525,11 +525,15 @@ int main(){
 			int parsed = sscanf(serial_buf, "%*s %x %x", &start_addr, &inst_count);
 			if(parsed < 2){
 				fast_serial_printf("Invalid request\r\n");
+				continue;
 			}
-
 			// Check that the instructions will fit in the do_cmds array
-			if(inst_count + start_addr > MAX_INSTR){
+			else if(inst_count + start_addr > MAX_INSTR){
 				fast_serial_printf("Invalid address and/or too many instructions (%d + %d).\r\n", start_addr, inst_count);
+				continue;
+			}
+			else{
+				fast_serial_printf("ready\r\n");
 			}
 
 			// reset do_cmd_count to start_address

--- a/prawn_do/prawn_do.c
+++ b/prawn_do/prawn_do.c
@@ -519,17 +519,21 @@ int main(){
 		// Add many command: read in a fixed number of binary integers without separation,
 		// append to command array
 		else if(strncmp(serial_buf, "adm", 3) == 0){
-			// Get how many instructions this adm command contains
+			// Get how many instructions this adm command contains and where to insert them
+			uint32_t start_addr;
 			uint32_t inst_count;
-			int parsed = sscanf(serial_buf, "%*s %x", &inst_count);
-			if(parsed < 1){
+			int parsed = sscanf(serial_buf, "%*s %x %x", &start_addr, &inst_count);
+			if(parsed < 2){
 				fast_serial_printf("Invalid request\r\n");
 			}
 
 			// Check that the instructions will fit in the do_cmds array
-			if(inst_count + do_cmd_count >= MAX_DO_CMDS - 3){
-				fast_serial_printf("Too many DO commands (%d + %d). Please use resources more efficiently or increase MAX_DO_CMDS and recompile.\r\n", do_cmd_count, inst_count);
+			if(inst_count + start_addr >= MAX_DO_CMDS - 3){
+				fast_serial_printf("Invalid address and/or too many instructions (%d + %d).\r\n", start_addr, inst_count);
 			}
+
+			// reset do_cmd_count to start_address
+			do_cmd_count = start_addr * 2;
 
 			// It takes 6 bytes to describe an instruction: 2 bytes for values, 4 bytes for time
 			uint32_t inst_per_buffer = SERIAL_BUFFER_SIZE / 6;

--- a/prawn_do/prawn_do.c
+++ b/prawn_do/prawn_do.c
@@ -528,7 +528,7 @@ int main(){
 			}
 
 			// Check that the instructions will fit in the do_cmds array
-			if(inst_count + start_addr >= MAX_DO_CMDS - 3){
+			if(inst_count + start_addr > MAX_INSTR){
 				fast_serial_printf("Invalid address and/or too many instructions (%d + %d).\r\n", start_addr, inst_count);
 			}
 


### PR DESCRIPTION
This PR has `adm` respond with `ready\r\n` before listening for the binary read. This allows the user to check for issues in the command, without incurring the timeout penalty during normal operation.

It also prevents bugs where erroneous commands did not stop execution of the `adm` command.

Finally, I updated the examples in the readme to be python scripts, hopefully making the `add` and `adm` commands a bit easier to use.