### PR TITLE
Add null terminator to strings returned from fast_serial_read_until

### DIFF
--- a/prawn_do/fast_serial.c
+++ b/prawn_do/fast_serial.c
@@ -35,7 +35,7 @@ uint32_t fast_serial_read(const char * buffer, uint32_t buffer_size){
 // Read bytes until terminator reached (blocks until terminator or buffer_size is reached)
 uint32_t fast_serial_read_until(char * buffer, uint32_t buffer_size, char until){
 	uint32_t buffer_idx = 0;
-	while(buffer_idx < buffer_size){
+	while(buffer_idx < buffer_size - 1){
 		while(fast_serial_read_available() > 0){
 			int32_t next_char = tud_cdc_read_char();
 
@@ -51,6 +51,7 @@ uint32_t fast_serial_read_until(char * buffer, uint32_t buffer_size, char until)
 		}
 		fast_serial_task();
 	}
+	buffer[buffer_idx] = '\0'; // Null terminate string
 	return buffer_idx;
 }
 

--- a/prawn_do/fast_serial.h
+++ b/prawn_do/fast_serial.h
@@ -46,6 +46,7 @@ static inline uint32_t fast_serial_read_atomic(const char * buffer, uint32_t buf
 uint32_t fast_serial_read(const char * buffer, uint32_t buffer_size);
 
 // Read bytes until terminator reached (blocks until terminator or buffer_size is reached)
+// Adds null terminator to buffer after read completes (reserving one byte in buffer for this)
 uint32_t fast_serial_read_until(char * buffer, uint32_t buffer_size, char until);
 
 // Clear read FIFO (without reading it)


### PR DESCRIPTION
This fixes a bug where sscanf could continue reading part of an old command if the most recent command is shorter.